### PR TITLE
Remove dependobot checks on codegenerated repo

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,2 @@
 ---
 version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"
-  - package_manager: "docker"
-    directory: "/"
-    update_schedule: "monthly"


### PR DESCRIPTION
The repo is code-generate, and so dependabot doesn't need to be pushing updates in this repo but the template repo.