### PR TITLE
fix: crypto-js vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "got": "^10.2.2",
     "lodash": "^4.17.15",
     "uuid": "^7.0.2",
-    "crypto-js": "3.1.9-1",
+    "crypto-js": "3.2.1",
     "buffer-equal-constant-time": "1.0.1",
     "qs": "^6.9.1"
   },


### PR DESCRIPTION
According to #86, update the version of `crypto-js` module to fix the [vulnerability](https://snyk.io/vuln/SNYK-JS-CRYPTOJS-548472) .