### PR TITLE
fixing types and other

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ typings/
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+/dist
+.idea

--- a/src/services/paymentService.ts
+++ b/src/services/paymentService.ts
@@ -14,7 +14,7 @@ interface PaymentCreateRequest {
   // Amount, in the lowest denomination for the currency (e.g. pence in GBP, cents
   // in EUR).
 
-  amount: string;
+  amount: number;
 
   // The amount to be deducted from the payment as the OAuth app's fee, in the
   // lowest denomination for the currency (e.g. pence in GBP, cents in EUR).

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -2441,7 +2441,7 @@ export enum PayerAuthorisationStatus {
 export interface Payment {
   // Amount, in the lowest denomination for the currency (e.g. pence in GBP,
   // cents in EUR).
-  amount: string;
+  amount: number;
 
   // Amount [refunded](#core-endpoints-refunds), in the lowest denomination for
   // the currency (e.g. pence in GBP, cents in EUR).

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -58,5 +58,6 @@ function InvalidSignatureError() {
 
 export {
   parse,
-  verifySignature
+  verifySignature,
+  InvalidSignatureError
 }

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -9,9 +9,9 @@
  * is genuinely from GoCardless, and secondly it parses each `event` object in the
  * JSON object into an `GoCardless.Event` class.
  */
-
-const cryptoJS = require('crypto-js');
-const safeCompare = require('buffer-equal-constant-time');
+import cryptoJS from 'crypto-js';
+import safeCompare from 'buffer-equal-constant-time';
+import type {Event} from './types/Types';
 
 function InvalidSignatureError() {
   this.message =
@@ -29,11 +29,10 @@ function InvalidSignatureError() {
  * @signatureHeader [string]: The signature included in the webhook request, as specified
  *   by the `Webhook-Signature` header.
  */
-function parse(body, webhookSecret, signatureHeader) {
+ function parse(body: string, webhookSecret: string, signatureHeader: string) {
   verifySignature(body, webhookSecret, signatureHeader);
 
-  const eventsData = JSON.parse(body)['events'];
-  return eventsData.map(eventJson => eventJson);
+  return JSON.parse(body)['events'] as Event[];
 }
 
 /**
@@ -46,7 +45,7 @@ function parse(body, webhookSecret, signatureHeader) {
  * @signatureHeader [string]: The signature included in the webhook request, as specified
  *   by the `Webhook-Signature` header.
  */
-function verifySignature(body, webhookSecret, signatureHeader) {
+ function verifySignature(body:string, webhookSecret:string, signatureHeader:string) {
   const rawDigest = cryptoJS.HmacSHA256(body, webhookSecret);
 
   const bufferDigest = Buffer.from(rawDigest.toString(cryptoJS.enc.Hex));
@@ -57,7 +56,7 @@ function verifySignature(body, webhookSecret, signatureHeader) {
   }
 }
 
-module.exports = {
+export {
   parse,
-  InvalidSignatureError,
-};
+  verifySignature
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
       "module": "commonjs",
-      "moduleResolution": "Node",
       "newLine": "lf",
       "esModuleInterop": true,
       "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
- Adding dist and .idea to .gitignore (helps when you're trying to improve this lib)
- Changing `string` to `number` for payment (would probably need to be changed for many more) since it fits with your documentation: https://developer.gocardless.com/api-reference/#payments-create-a-payment _Everything seems to be numbered, not string, why keeping string in types :) ?_
- Adding types to webhook (you already had the types defined, but the function did not provide them. We could not use it in typescript projects)
- Changing the webhook export (since again, was not able to import properly in typescript). _This is a duplicate from_: https://github.com/gocardless/gocardless-nodejs/pull/111 