### PR TITLE
Release 3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -736,9 +736,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.11.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
-          "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
+          "version": "18.11.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+          "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
         }
       }
     },
@@ -800,9 +800,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.11.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
-          "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
+          "version": "18.11.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+          "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
         }
       }
     },
@@ -842,9 +842,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.11.14",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
-          "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
+          "version": "18.11.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+          "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
         }
       }
     },
@@ -3177,9 +3177,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "dev": true
     },
     "jsprim": {
@@ -3484,9 +3484,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.7.tgz",
-      "integrity": "sha512-EJ3rzxL9pTWPjk5arA0s0dgXpnyiAbJDE6wHT62g7VsgrgQgmmZ+Ru++M1BFofncWja+Pnn3rEr3fieRySAdKQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
     },
     "normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gocardless-nodejs",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gocardless-nodejs",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Node.js client for the GoCardless API - a powerful, simple solution for the collection of recurring bank-to-bank payments",
   "author": "GoCardless Ltd <client-libraries@gocardless.com>",
   "repository": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ enum Environments {
   Sandbox = 'SANDBOX',
 }
 
-const CLIENT_VERSION = '3.6.1';
+const CLIENT_VERSION = '3.7.0';
 const API_VERSION = '2015-07-06';
 
 export { Environments, CLIENT_VERSION, API_VERSION };

--- a/src/services/blockService.ts
+++ b/src/services/blockService.ts
@@ -266,7 +266,7 @@ export class BlockService {
   ): Promise<BlockListResponse> {
     const urlParameters = [];
     const requestParams = {
-      path: '/block_by_ref',
+      path: '/blocks/block_by_ref',
       method: 'post',
       urlParameters,
       requestParameters,

--- a/src/services/creditorService.ts
+++ b/src/services/creditorService.ts
@@ -30,12 +30,12 @@ interface CreditorCreateRequest {
   // [ISO 3166-1 alpha-2
   // code.](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
 
-  country_code?: string;
+  country_code: string;
 
   // The type of business of the creditor. Currently, `individual`, `company`,
   // `charity`, `partnership`, and `trust` are supported.
 
-  creditor_type?: Types.CreditorCreditorType;
+  creditor_type: Types.CreditorCreditorType;
 
   // The creditor's name.
 


### PR DESCRIPTION
Updates include:
- Making `creditor_type` and `country_code` required when creating creditors via the API (for payment providers);
- Removing `null` as an allowed value for `creditor_type` when creating creditors.