### PR TITLE
chore: update library docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For a full list of available resources, visit the [GoCardless API reference](htt
 ```js
 const uuidv4 = require('uuid/v4');
 
-// Create a new payment.
+// Create a new payment with an idempotency key
 const payment = await client.payments.create(
   {
     amount: 100,

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const payment = await client.payments.create(
     currency: "GBP",
     links: { mandate: "MD123" },
   },
-  { idempotencyKey: uuidv4() },
+  uuidv4(),
 );
 
 // List the first three payments past a certain date.


### PR DESCRIPTION
We currently pass the entire key=>value pair as the idempotency key in the nodejs client library when the user specifies uuid().

This causes issues as we end up passing an object rather than a string to payments service which results in 409s.

![Screenshot 2024-02-06 at 10 33 52](https://github.com/gocardless/gocardless-nodejs/assets/24224327/3afc0be5-16ec-4039-b588-db7daeeab141)

This is happening because of the way we are advising integrators to pass the idempotency key. This PR updates the readme to correct this misinformation.