### PR TITLE
Add pull_request trigger to CI workflow

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -34,6 +34,19 @@ jobs:
       with:
         path: "dist"
 
+  all-tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [test, transpile]
+    if: always()
+    steps:
+    - name: Check test/transpile job status
+      run: |
+        if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.transpile.result }}" != "success" ]; then
+          echo "test or transpile job did not succeed"
+          exit 1
+        fi
+
   check_version:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,5 +1,9 @@
 name: test & publish
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 permissions:
   id-token: write  # Required for OIDC


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger alongside the existing `push` trigger so `test`/`transpile` run against fork PRs, not just pushes to the repo.
- Restricts the `push` trigger to `master` only (post-merge publish flow is unaffected - it already gates on `github.ref == 'refs/heads/master'`).

## Why
Part of IX-2323: setting up required status checks across GoCardless's public client library repos so we can safely enable auto-merge. A push-only trigger never runs against a fork PR's head commit, so requiring `test`/`transpile` in branch protection would otherwise block every external contribution.

## Test plan
- [ ] Confirm `test` and `transpile` appear as checks on this PR