### PR TITLE
template-changes

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -126,10 +126,11 @@ jobs:
         git tag v${{ needs.check_version.outputs.version }}
         git push origin v${{ needs.check_version.outputs.version }}
         NOTES="${{ steps.notes.outputs.notes }}"
+        TAG="v${{ needs.check_version.outputs.version }}"
         if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
-          gh release create v${{ needs.check_version.outputs.version }} --notes "$NOTES"
+          gh release create "$TAG" --title "$TAG" --notes "$NOTES"
         else
-          gh release create v${{ needs.check_version.outputs.version }} --generate-notes
+          gh release create "$TAG" --title "$TAG" --generate-notes
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`gh release create` was leaving the release title blank when notes come from the changelog (`--notes`), so GitHub fell back to showing the merge commit message as the title (e.g. v8.6.0 showed as "Merge pull request #253 from gocardless/template-changes" instead of "v8.6.0").
